### PR TITLE
Add except support to stripBBCodeTags function

### DIFF
--- a/src/BBCodeParser.php
+++ b/src/BBCodeParser.php
@@ -153,13 +153,19 @@ class BBCodeParser
     }
 
     /**
-     * Remove all BBCode
+     * Remove all BBCode except the $except parameter names
      * @param  string $source
+     * @param  array $except an array of the parser names
      * @return string Parsed text
      */
-    public function stripBBCodeTags($source)
+    public function stripBBCodeTags($source, $except = [])
     {
         foreach ($this->parsers as $name => $parser) {
+            if (in_array(strtolower($name), $except)) {
+                // does not have to strip this bbcode tag
+                continue;
+            }
+
             $source = $this->searchAndReplace($parser['pattern'].'i', $parser['content'], $source);
         }
         return $source;

--- a/tests/BBCodeParserTest.php
+++ b/tests/BBCodeParserTest.php
@@ -212,6 +212,17 @@ class BBCodeParserTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals($result, 'I am one beautiful bird!');
     }
 
+    public function testRemovalOfBBCodeTagsExcept()
+    {
+        $b = new BBCodeParser;
+        $result = $b->stripBBCodeTags('[u]Magpie[/u] is one [b]beautiful[/b] bird!', ['underline']);
+        $this->assertEquals($result, '[u]Magpie[/u] is one beautiful bird!');
+
+        $b = new BBCodeParser;
+        $result = $b->stripBBCodeTags('[QUOTE=Magpie]I am one [B]beautiful[/B] bird![/QUOTE]', ['quote', 'namedquote', 'bold']);
+        $this->assertEquals($result, '[QUOTE=Magpie]I am one [B]beautiful[/B] bird![/QUOTE]');
+    }
+
     public function testStatelessParsers()
     {
         $b = new BBCodeParser;


### PR DESCRIPTION
These small modification may be useful when You don't want to strip all bbcode tags with the stripBBCodeTags function.